### PR TITLE
Fix/prune test refactor

### DIFF
--- a/pkg/cmd/apply/prune.go
+++ b/pkg/cmd/apply/prune.go
@@ -177,8 +177,10 @@ func (p *pruner) getNamespacesToPrune(o *ApplyOptions) ([]string, error) {
 	// Always include visited namespaces from the current apply operation
 	namespacesToPrune.Insert(sets.List(p.visitedNamespaces)...)
 
-	// If a specific namespace is set, only consider that namespace
-	if o.Namespace != "" {
+	// If a specific namespace is set and it's not the enforced default namespace,
+	// only consider that namespace. We need to check if the namespace was explicitly
+	// set by the user vs. defaulted by kubectl.
+	if o.EnforceNamespace {
 		namespacesToPrune.Insert(o.Namespace)
 		return sets.List(namespacesToPrune), nil
 	}

--- a/pkg/cmd/apply/prune.go
+++ b/pkg/cmd/apply/prune.go
@@ -24,6 +24,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/cli-runtime/pkg/printers"
@@ -76,7 +77,13 @@ func (p *pruner) pruneAll(o *ApplyOptions) error {
 		return fmt.Errorf("error retrieving RESTMappings to prune: %v", err)
 	}
 
-	for n := range p.visitedNamespaces {
+	// Determine which namespaces to check for pruning
+	namespacesToPrune, err := p.getNamespacesToPrune(o)
+	if err != nil {
+		return fmt.Errorf("error determining namespaces to prune: %v", err)
+	}
+
+	for _, n := range namespacesToPrune {
 		for _, m := range namespacedRESTMappings {
 			if err := p.prune(n, m); err != nil {
 				return fmt.Errorf("error pruning namespaced object %v: %v", m.GroupVersionKind, err)
@@ -159,4 +166,141 @@ func asDeleteOptions(cascadingStrategy metav1.DeletionPropagation, gracePeriod i
 	}
 	options.PropagationPolicy = &cascadingStrategy
 	return options
+}
+
+// getNamespacesToPrune returns the set of namespaces that should be checked for pruning.
+// This includes visited namespaces from the current apply operation and any additional
+// namespaces that contain resources matching the label selector.
+func (p *pruner) getNamespacesToPrune(o *ApplyOptions) ([]string, error) {
+	namespacesToPrune := sets.New[string]()
+
+	// Always include visited namespaces from the current apply operation
+	namespacesToPrune.Insert(sets.List(p.visitedNamespaces)...)
+
+	// If a specific namespace is set, only consider that namespace
+	if o.Namespace != "" {
+		namespacesToPrune.Insert(o.Namespace)
+		return sets.List(namespacesToPrune), nil
+	}
+
+	// If no specific namespace and we have a label selector, find all namespaces
+	// that contain resources matching the selector
+	if p.labelSelector != "" {
+		namespacesWithMatchingResources, err := p.findNamespacesWithMatchingResources(o)
+		if err != nil {
+			return nil, err
+		}
+		namespacesToPrune.Insert(namespacesWithMatchingResources...)
+	}
+
+	return sets.List(namespacesToPrune), nil
+}
+
+// findNamespacesWithMatchingResources finds all namespaces that contain resources
+// matching the label selector
+func (p *pruner) findNamespacesWithMatchingResources(o *ApplyOptions) ([]string, error) {
+	namespacesWithResources := sets.New[string]()
+
+	namespacedRESTMappings, _, err := prune.GetRESTMappings(o.Mapper, o.PruneResources, o.Namespace != "")
+	if err != nil {
+		return nil, err
+	}
+
+	// Get all namespaces
+	namespaceList, err := p.dynamicClient.Resource(schema.GroupVersionResource{
+		Group:    "",
+		Version:  "v1",
+		Resource: "namespaces",
+	}).List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list namespaces: %v", err)
+	}
+
+	namespaces, err := meta.ExtractList(namespaceList)
+	if err != nil {
+		return nil, err
+	}
+
+	// Check each namespace for resources matching the label selector
+	for _, nsObj := range namespaces {
+		nsMetadata, err := meta.Accessor(nsObj)
+		if err != nil {
+			continue
+		}
+		nsName := nsMetadata.GetName()
+
+		// Skip system namespaces unless they were explicitly visited
+		if isSystemNamespace(nsName) && !p.visitedNamespaces.Has(nsName) {
+			continue
+		}
+
+		// Check if this namespace has any resources matching our criteria
+		hasMatchingResources, err := p.namespaceHasMatchingResources(nsName, namespacedRESTMappings)
+		if err != nil {
+			// Log error but continue with other namespaces
+			continue
+		}
+
+		if hasMatchingResources {
+			namespacesWithResources.Insert(nsName)
+		}
+	}
+
+	return sets.List(namespacesWithResources), nil
+}
+
+// namespaceHasMatchingResources checks if a namespace contains any resources
+// that match the label selector and have the last-applied-config annotation
+func (p *pruner) namespaceHasMatchingResources(namespace string, mappings []*meta.RESTMapping) (bool, error) {
+	for _, mapping := range mappings {
+		objList, err := p.dynamicClient.Resource(mapping.Resource).
+			Namespace(namespace).
+			List(context.TODO(), metav1.ListOptions{
+				LabelSelector: p.labelSelector,
+				FieldSelector: p.fieldSelector,
+			})
+		if err != nil {
+			// If we can't list this resource type, skip it
+			continue
+		}
+
+		objs, err := meta.ExtractList(objList)
+		if err != nil {
+			continue
+		}
+
+		// Check if any objects have the last-applied-config annotation
+		for _, obj := range objs {
+			metadata, err := meta.Accessor(obj)
+			if err != nil {
+				continue
+			}
+
+			annots := metadata.GetAnnotations()
+			if _, ok := annots[corev1.LastAppliedConfigAnnotation]; ok {
+				return true, nil
+			}
+		}
+	}
+
+	return false, nil
+}
+
+// isSystemNamespace returns true if the namespace is a system namespace
+// that should be excluded from pruning unless explicitly visited
+func isSystemNamespace(namespace string) bool {
+	systemNamespaces := []string{
+		"kube-system",
+		"kube-public",
+		"kube-node-lease",
+		"default",
+	}
+
+	for _, sysNs := range systemNamespaces {
+		if namespace == sysNs {
+			return true
+		}
+	}
+
+	return false
 }

--- a/pkg/cmd/apply/prune_test.go
+++ b/pkg/cmd/apply/prune_test.go
@@ -17,19 +17,26 @@ limitations under the License.
 package apply
 
 import (
-	"bytes"
+	"context"
+	"encoding/json"
 	"io"
 	"net/http"
-	"path"
+	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
-	"k8s.io/cli-runtime/pkg/resource"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/rest/fake"
+	clientgotesting "k8s.io/client-go/testing"
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
 	"k8s.io/kubectl/pkg/scheme"
 )
@@ -41,179 +48,316 @@ const (
 	podFile22    = "prune-pod-second-2.yaml"
 )
 
-const (
-	firstPodsCollection  = "/namespaces/first/pods"
-	secondPodsCollection = "/namespaces/second/pods"
-)
-
-var (
-	codecPrune = scheme.Codecs.LegacyCodec(scheme.Scheme.PrioritizedVersionsAllGroups()...)
-)
+func UnstructuredToNamespacePruneTest(u *unstructured.Unstructured, t *testing.T) *corev1.Namespace {
+	if u == nil {
+		return nil
+	}
+	var ns corev1.Namespace
+	errConv := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, &ns)
+	if errConv != nil {
+		t.Logf("Error converting unstructured to namespace: %v", errConv)
+		return nil
+	}
+	return &ns
+}
 
 func TestPruneTwoNamespaces(t *testing.T) {
-
 	cmdtesting.InitTestErrorHandler(t)
 
-	// Read the pod from the first file that will be kept
-	podFirst := readUnstructuredFromFile(t, testDataPath+podFile11)
+	podFirstFromFile := readUnstructuredFromFile(t, filepath.Join(testDataPath, podFile11))
+	podSecond1FromFile := readUnstructuredFromFile(t, filepath.Join(testDataPath, podFile21))
+	podSecond2FromFile := readUnstructuredFromFile(t, filepath.Join(testDataPath, podFile22))
 
-	podSecond1 := readUnstructuredFromFile(t, testDataPath+podFile21)
-	podSecond2 := readUnstructuredFromFile(t, testDataPath+podFile22)
+	initialInTrackerPod1 := podFirstFromFile.DeepCopy()
+	initialInTrackerPod1.SetUID("uid-p11")
+	initialInTrackerPod2 := podSecond1FromFile.DeepCopy()
+	initialInTrackerPod2.SetUID("uid-p21")
+	initialInTrackerPod3 := podSecond2FromFile.DeepCopy()
+	initialInTrackerPod3.SetUID("uid-p22")
 
-	tf := cmdtesting.NewTestFactory()
+	nsFirstIn := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "first", UID: "uid-ns-first"}}
+	nsSecondIn := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "second", UID: "uid-ns-second"}}
+
+	tf := cmdtesting.NewTestFactory().WithNamespace("first")
 	defer tf.Cleanup()
 
-	// these are created for simple book keeping an ease of lookup.
-	// the book keeping is made in the most simple way possible to avoid creating a lot of test code.
-	// the pods are specifically named so that you don't have to even keep track of a namespace.
-	podMap := map[string]*unstructured.Unstructured{
-		"p11": podFirst,
-		"p21": podSecond1,
-		"p22": podSecond2,
-	}
+	gvrPod := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}
+	gvrNs := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "namespaces"}
 
-	podExistMap := map[string]bool{
-		"p11": false,
-		"p21": false,
-		"p22": false,
-	}
+	allInitialObjects := []runtime.Object{initialInTrackerPod1, initialInTrackerPod2, initialInTrackerPod3, nsFirstIn, nsSecondIn}
+	tf.FakeDynamicClient = dynamicfake.NewSimpleDynamicClient(scheme.Scheme, allInitialObjects...)
 
-	// Set up the fake REST client to handle HTTP requests
-	// NOTE that a lot of the error cases are not handled here to avoid generating too much test code.
-	// we would rather see a "panic" than add handlers where we don't expect
-	tf.UnstructuredClient = &fake.RESTClient{
-		NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
-		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
-			switch p, m := req.URL.Path, req.Method; {
+	var podFirstLive, podSecond1Live, podSecond2Live *unstructured.Unstructured
+	var nsFirstForHandler, nsSecondForHandler *corev1.Namespace
+	// var err error // err is used by ToOptions later, avoid redeclaration if not careful
 
-			// Handle all the namespace GET's they all "exist"
+	unstrPod1, errGet1 := tf.FakeDynamicClient.Resource(gvrPod).Namespace(initialInTrackerPod1.GetNamespace()).Get(context.TODO(), initialInTrackerPod1.GetName(), metav1.GetOptions{})
+	if errGet1 != nil {t.Fatalf("Failed to get pod %s from tracker: %v", initialInTrackerPod1.GetName(), errGet1)}
+	podFirstLive = unstrPod1
 
-			case strings.HasPrefix(p, "/api/v1/namespaces/") && m == "GET":
-				namespace := strings.TrimPrefix(p, "/api/v1/namespaces/")
-				// Return namespace exists
-				nsResponse := `{
-					"kind": "Namespace",
-					"apiVersion": "v1",
-					"metadata": {
-						"name": "` + namespace + `"
-					}
-				}`
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Header:     cmdtesting.DefaultHeader(),
-					Body:       io.NopCloser(strings.NewReader(nsResponse))}, nil
+	unstrPod2, errGet2 := tf.FakeDynamicClient.Resource(gvrPod).Namespace(initialInTrackerPod2.GetNamespace()).Get(context.TODO(), initialInTrackerPod2.GetName(), metav1.GetOptions{})
+	if errGet2 != nil {t.Fatalf("Failed to get pod %s from tracker: %v", initialInTrackerPod2.GetName(), errGet2)}
+	podSecond1Live = unstrPod2
 
-			// all the LISTS
-			case strings.HasPrefix(p, firstPodsCollection) && m == "GET" && strings.Contains(p, "?"):
-				// Return list with p11 pod for first namespace
-				pb, _ := runtime.Encode(codecPrune, podMap["p11"])
-				listResponse := `{"kind":"List","apiVersion":"v1","items":[` + string(pb) + `]}`
-				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: io.NopCloser(strings.NewReader(listResponse))}, nil
-			case strings.HasPrefix(p, secondPodsCollection) && m == "GET" && strings.Contains(p, "?"):
-				// Handle the list response for pruning
-				p1b, _ := runtime.Encode(codecPrune, podMap["p21"])
-				p2b, _ := runtime.Encode(codecPrune, podMap["p22"])
-				listResponse := `{"kind":"List","apiVersion":"v1","items":[` + string(p1b) + `,` + string(p2b) + `]}`
-				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: io.NopCloser(strings.NewReader(listResponse))}, nil
+	unstrPod3, errGet3 := tf.FakeDynamicClient.Resource(gvrPod).Namespace(initialInTrackerPod3.GetNamespace()).Get(context.TODO(), initialInTrackerPod3.GetName(), metav1.GetOptions{})
+	if errGet3 != nil {t.Fatalf("Failed to get pod %s from tracker: %v", initialInTrackerPod3.GetName(), errGet3)}
+	podSecond2Live = unstrPod3
 
-			// All the GETs return 404
-			// the reason is that if we return the objects here kubectl decides that they already
-			// exist and tries to do a patch.
-			case urlInCollections(p) && (m == "GET" || m == "PATCH"):
-				name := path.Base(p)
+	nsFirstLiveUntyped, errNs1 := tf.FakeDynamicClient.Resource(gvrNs).Get(context.TODO(), nsFirstIn.GetName(), metav1.GetOptions{})
+	if errNs1 != nil {t.Fatalf("Failed to get ns %s from tracker: %v", nsFirstIn.GetName(), errNs1)}
+	nsFirstForHandler = UnstructuredToNamespacePruneTest(nsFirstLiveUntyped, t)
+	if nsFirstForHandler == nil {t.Fatalf("nsFirstForHandler is nil after conversion")}
 
-				if !podExistMap[name] {
-					// If the pod does not exist, return 404
-					return &http.Response{
-						StatusCode: http.StatusNotFound,
-						Header:     cmdtesting.DefaultHeader(),
-					}, nil
-				}
+	nsSecondLiveUntyped, errNs2 := tf.FakeDynamicClient.Resource(gvrNs).Get(context.TODO(), nsSecondIn.GetName(), metav1.GetOptions{})
+	if errNs2 != nil {t.Fatalf("Failed to get ns %s from tracker: %v", nsSecondIn.GetName(), errNs2)}
+	nsSecondForHandler = UnstructuredToNamespacePruneTest(nsSecondLiveUntyped, t)
+	if nsSecondForHandler == nil {t.Fatalf("nsSecondForHandler is nil after conversion")}
 
-				pod := podMap[name]
-				podBytes, _ := runtime.Encode(codecPrune, pod)
-				bodyPod := io.NopCloser(bytes.NewReader(podBytes))
-				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: bodyPod}, nil
+	t.Logf("UIDs after GET from tracker: p11: %s, p21: %s, p22: %s, nsFirst: %s, nsSecond: %s",
+		podFirstLive.GetUID(), podSecond1Live.GetUID(), podSecond2Live.GetUID(),
+		nsFirstForHandler.GetUID(), nsSecondForHandler.GetUID())
 
-			// All the Pod POSTs
-			case urlInCollections(p) && m == "POST":
+	tf.FakeDynamicClient.PrependReactor("list", "pods", func(action clientgotesting.Action) (handled bool, ret runtime.Object, err error) {
+		listAction := action.(clientgotesting.ListAction)
+		t.Logf("FakeDynamicClient LIST reactor for pods: Namespace=%s, Selector=%s", listAction.GetNamespace(), listAction.GetListRestrictions().Labels.String())
+		listOptions := metav1.ListOptions{
+			LabelSelector: listAction.GetListRestrictions().Labels.String(),
+			FieldSelector: listAction.GetListRestrictions().Fields.String(),
+		}
+		// Correct GVK for PodList is corev1.SchemeGroupVersion.WithKind("PodList")
+		// The tracker should use this if scheme is correctly registered.
+		objList, trackerErr := tf.FakeDynamicClient.Tracker().List(gvrPod, corev1.SchemeGroupVersion.WithKind("PodList"), listAction.GetNamespace(), listOptions)
+		if trackerErr != nil {
+			t.Logf("Error from tracker during LIST reactor: %v", trackerErr)
+		} else {
+			if list, ok := objList.(*unstructured.UnstructuredList); ok { // Tracker().List returns runtime.Object, cast to UnstructuredList
+				t.Logf("LIST reactor: Tracker returned %d items for %s/%s selector %s", len(list.Items), listAction.GetNamespace(), "pods", listAction.GetListRestrictions().Labels.String())
+			} else if list, ok := objList.(*corev1.PodList); ok { // Or it might return a typed list if scheme is good
+                 t.Logf("LIST reactor: Tracker returned %d items (typed PodList) for %s/%s selector %s", len(list.Items), listAction.GetNamespace(), "pods", listAction.GetListRestrictions().Labels.String())
+            }
+		}
+		return false, nil, nil
+	})
 
-				name := readPodName(t, req.Body)
-				podExistMap[name] = true
-				pod := podMap[name]
-				setLastAppliedConfigAnnotation(podFirst)
-				podBytes, _ := runtime.Encode(codecPrune, pod)
-				bodyPod := io.NopCloser(bytes.NewReader(podBytes))
-				return &http.Response{StatusCode: http.StatusCreated, Header: cmdtesting.DefaultHeader(), Body: bodyPod}, nil
-
-			// All the DELETEs
-			case urlInCollections(p) && m == "DELETE":
-				name := path.Base(p)
-				podExistMap[name] = false
-				pod := podMap[name]
-				podBytes, _ := runtime.Encode(codecPrune, pod)
-				bodyPod := io.NopCloser(bytes.NewReader(podBytes))
-				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: bodyPod}, nil
-
-			default:
-				t.Fatalf("unexpected request: %s %s", m, p)
-				return nil, nil
-			}
-		}),
-	}
 	tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
 
+	tf.UnstructuredClient = &fake.RESTClient{
+		NegotiatedSerializer: scheme.Codecs.WithoutConversion(),
+		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+			responseCodec := scheme.Codecs.LegacyCodec(corev1.SchemeGroupVersion)
+			path := req.URL.Path
+			t.Logf("UnstructuredClient received: Method=%s, Path=%s", req.Method, path)
+
+			switch req.Method {
+			case "GET":
+				if strings.HasPrefix(path, "/namespaces/"+podFirstLive.GetNamespace()+"/pods/"+podFirstLive.GetName()) {
+					t.Logf("Serving GET for podFirstLive (UID: %s)", podFirstLive.GetUID())
+					return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(responseCodec, podFirstLive)}, nil
+				}
+				if strings.HasPrefix(path, "/namespaces/"+podSecond1Live.GetNamespace()+"/pods/"+podSecond1Live.GetName()) {
+					t.Logf("Serving GET for podSecond1Live (UID: %s)", podSecond1Live.GetUID())
+					return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(responseCodec, podSecond1Live)}, nil
+				}
+				if strings.HasPrefix(path, "/namespaces/"+podSecond2Live.GetNamespace()+"/pods/"+podSecond2Live.GetName()) {
+					t.Logf("Serving GET for podSecond2Live (UID: %s)", podSecond2Live.GetUID())
+					return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(responseCodec, podSecond2Live)}, nil
+				}
+				if strings.HasPrefix(path, "/api/v1/namespaces/"+nsFirstForHandler.GetName()) && !strings.Contains(path, "/pods/") {
+					t.Logf("Serving GET for nsFirstForHandler (UID: %s)", nsFirstForHandler.GetUID())
+					return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(responseCodec, nsFirstForHandler)}, nil
+				}
+				if strings.HasPrefix(path, "/api/v1/namespaces/"+nsSecondForHandler.GetName()) && !strings.Contains(path, "/pods/") {
+					t.Logf("Serving GET for nsSecondForHandler (UID: %s)", nsSecondForHandler.GetUID())
+					return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(responseCodec, nsSecondForHandler)}, nil
+				}
+			case "PATCH":
+				pathParts := strings.Split(strings.Trim(path, "/"), "/")
+				if len(pathParts) == 4 && pathParts[0] == "namespaces" && pathParts[2] == "pods" {
+					ns, name := pathParts[1], pathParts[3]
+					t.Logf("PATCH Pod: ns=%s, name=%s", ns, name)
+					var liveObjectToUpdate *unstructured.Unstructured
+
+					if ns == podFirstLive.GetNamespace() && name == podFirstLive.GetName() {
+						liveObjectToUpdate = podFirstLive
+					} else if ns == podSecond1Live.GetNamespace() && name == podSecond1Live.GetName() {
+						liveObjectToUpdate = podSecond1Live
+					} else if ns == podSecond2Live.GetNamespace() && name == podSecond2Live.GetName() {
+						liveObjectToUpdate = podSecond2Live
+					}
+
+					if liveObjectToUpdate != nil {
+						t.Logf("Found live object to patch: %s/%s (UID before patch: %s)", ns, name, liveObjectToUpdate.GetUID())
+						_, errRead := io.ReadAll(req.Body)
+						if errRead != nil {
+							t.Logf("Error reading patch body for %s/%s: %v", ns, name, errRead)
+						}
+
+						errAnnotation := setLastAppliedConfigAnnotation(liveObjectToUpdate)
+						if errAnnotation != nil {
+							t.Logf("Error setting last-applied for %s/%s: %v", ns, name, errAnnotation)
+						}
+
+						annJson, _ := json.Marshal(liveObjectToUpdate.GetAnnotations())
+						t.Logf("Annotations on %s/%s after simulated patch: %s", ns, name, string(annJson))
+						t.Logf("UID of %s/%s when recording update: %s", ns, name, liveObjectToUpdate.GetUID())
+
+						updatedObjectForAction := liveObjectToUpdate.DeepCopy()
+						tf.FakeDynamicClient.Fake.Invokes(clientgotesting.NewUpdateAction(gvrPod, ns, updatedObjectForAction), updatedObjectForAction)
+						tf.FakeDynamicClient.Tracker().Update(gvrPod, updatedObjectForAction, ns)
+
+						t.Logf("Patch HTTP call for %s/%s successful (simulated), action recorded, tracker updated.", ns, name)
+						return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(responseCodec, liveObjectToUpdate)}, nil
+					}
+					t.Logf("PATCH target object not found in live map: %s/%s", ns, name)
+				}
+			case "POST":
+				pathParts := strings.Split(strings.Trim(path, "/"), "/")
+				if len(pathParts) == 3 && pathParts[0] == "namespaces" && pathParts[2] == "pods" {
+					ns := pathParts[1]
+					t.Logf("POST Pod to ns=%s", ns)
+					bodyBytes, errIoRead := io.ReadAll(req.Body)
+					if errIoRead != nil { t.Logf("Error reading POST body: %v", errIoRead); return &http.Response{StatusCode:http.StatusInternalServerError}, nil }
+
+					newPod := &unstructured.Unstructured{}
+					errDecode := runtime.DecodeInto(scheme.Codecs.UniversalDecoder(), bodyBytes, newPod)
+					if errDecode != nil { t.Logf("Error decoding POST body: %v", errDecode); return &http.Response{StatusCode:http.StatusBadRequest}, nil }
+
+					createdObjectForAction := newPod.DeepCopy()
+					errTrackerCreate := tf.FakeDynamicClient.Tracker().Create(gvrPod, createdObjectForAction, ns)
+					if errTrackerCreate != nil {t.Fatalf("Tracker create failed: %v", errTrackerCreate)}
+					tf.FakeDynamicClient.Fake.Invokes(clientgotesting.NewCreateAction(gvrPod, ns, createdObjectForAction), createdObjectForAction)
+
+					if newPod.GetName() == podFirstLive.GetName() { podFirstLive = createdObjectForAction }
+					if newPod.GetName() == podSecond1Live.GetName() { podSecond1Live = createdObjectForAction }
+					if newPod.GetName() == podSecond2Live.GetName() { podSecond2Live = createdObjectForAction }
+
+					t.Logf("POST for pod %s/%s successful (simulated), UID: %s", ns, newPod.GetName(), createdObjectForAction.GetUID())
+					return &http.Response{StatusCode: http.StatusCreated, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(responseCodec, createdObjectForAction)}, nil
+				}
+			}
+			t.Logf("UnstructuredClient: Path not handled or method not supported: %s %s", req.Method, req.URL.Path)
+			return &http.Response{ StatusCode: http.StatusNotFound, Header: cmdtesting.DefaultHeader(), Body:       io.NopCloser(strings.NewReader("UnstructuredClient: Path not handled: " + req.Method + " " + req.URL.Path))}, nil
+		}),
+	}
+
+	// --- First Apply Run ---
 	ioStreams, _, buf, errBuf := genericiooptions.NewTestIOStreams()
-	cmd := NewCmdApply("kubectl", tf, ioStreams)
-	cmd.Flags().Set("filename", testDataPath+podFile11)
-	cmd.Flags().Set("filename", testDataPath+podFile21)
-	cmd.Flags().Set("filename", testDataPath+podFile22)
-	cmd.Flags().Set("output", "name")
-	cmd.Run(cmd, []string{})
+	firstRunApplyFlags := NewApplyFlags(ioStreams)
+	firstRunCmd := &cobra.Command{}
+	firstRunApplyFlags.AddFlags(firstRunCmd)
 
-	if errBuf.String() != "" {
-		t.Fatalf("unexpected error output: %s", errBuf.String())
-	}
+	firstRunCmd.Flags().Set("filename", filepath.Join(testDataPath, podFile11))
+	firstRunCmd.Flags().Set("filename", filepath.Join(testDataPath, podFile21))
+	firstRunCmd.Flags().Set("filename", filepath.Join(testDataPath, podFile22))
+	firstRunCmd.Flags().Set("output", "name")
 
-	// we have asked for the names to be output so we should get all of them in the output string
-	outString := buf.String()
-	// at this point in time none of our pods should be deleted.
-	// and they all should be represented in the output
-	for name, exists := range podExistMap {
-		assert.True(t, exists, "pod %s should not be deleted", name)
-		assert.Contains(t, outString, "pod/"+name)
-	}
-
-	// the second run should prune the p2* pods
-	ioStreams, _, _, errBuf = genericiooptions.NewTestIOStreams()
-	cmd = NewCmdApply("kubectl", tf, ioStreams)
-	cmd.Flags().Set("filename", testDataPath+podFile11)
-	cmd.Flags().Set("prune", "true")
-	cmd.Flags().Set("selector", "test=managed")
-	cmd.Run(cmd, []string{})
-	if errBuf.String() != "" {
-		t.Fatalf("unexpected error output: %s", errBuf.String())
-	}
-
-	assert.False(t, podExistMap["p21"], "pod p21 should be deleted")
-	assert.False(t, podExistMap["p22"], "pod p22 should be deleted")
-}
-
-// urlInCollections checks if the given URL is part of the collections we are interested in.
-func urlInCollections(url string) bool {
-	return strings.HasPrefix(url, firstPodsCollection) ||
-		strings.HasPrefix(url, secondPodsCollection)
-}
-
-// readUnstructuredFromFile reads a request body and returns a names
-func readPodName(t *testing.T, body io.ReadCloser) string {
-	bodyBytes, err := io.ReadAll(body)
+	o, err := firstRunApplyFlags.ToOptions(tf, firstRunCmd, "kubectl", []string{})
 	if err != nil {
-		t.Fatalf("failed to read request body: %v", err)
+		t.Fatalf("Error creating ApplyOptions for first run: %v", err)
 	}
-	obj := &unstructured.Unstructured{}
-	if err := runtime.DecodeInto(codecPrune, bodyBytes, obj); err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	o.Namespace = ""
+	o.EnforceNamespace = false
+	o.ServerSideApply = false
+	t.Logf("UIDs before first o.Run() (from live vars): p11: %s, p21: %s, p22: %s", podFirstLive.GetUID(), podSecond1Live.GetUID(), podSecond2Live.GetUID())
+	if err := o.Run(); err != nil {
+		if tf.FakeDynamicClient != nil {
+			t.Logf("FakeDynamicClient actions at time of error (first run): %#v", tf.FakeDynamicClient.Actions())
+		}
+		t.Fatalf("unexpected error during first apply run: %v\nOutput: %s\nErrorOutput: %s", err, buf.String(), errBuf.String())
 	}
-	return obj.GetName()
+	t.Logf("UIDs after first o.Run() (from live vars): p11: %s, p21: %s, p22: %s", podFirstLive.GetUID(), podSecond1Live.GetUID(), podSecond2Live.GetUID())
+	visitedUIDsList := make([]string, 0, o.VisitedUids.Len())
+	for uid := range o.VisitedUids {
+		visitedUIDsList = append(visitedUIDsList, string(uid))
+	}
+	t.Logf("VisitedUids after first o.Run(): %v", visitedUIDsList)
+
+	outString := buf.String()
+	expectedOutputs := []string{
+		"pod/" + podFirstFromFile.GetName(),
+		"pod/" + podSecond1FromFile.GetName(),
+		"pod/" + podSecond2FromFile.GetName(),
+	}
+	for _, expected := range expectedOutputs {
+		assert.Contains(t, outString, expected, "Output of first apply should contain all applied pods")
+	}
+
+	firstRunActions := tf.FakeDynamicClient.Actions()
+	updateCountDuringFirstRun := 0
+	createCountDuringFirstRun := 0
+	for _, firstRunAction := range firstRunActions {
+		if firstRunAction.GetVerb() == "update" && firstRunAction.GetResource() == gvrPod {
+			updateCountDuringFirstRun++
+		}
+		if firstRunAction.GetVerb() == "create" && firstRunAction.GetResource() == gvrPod {
+			createCountDuringFirstRun++
+		}
+	}
+	assert.Equal(t, 3, updateCountDuringFirstRun, "Expected 3 update actions for the three pods in the first apply")
+	assert.Equal(t, 0, createCountDuringFirstRun, "Expected 0 create actions for the three pods in the first apply")
+	tf.FakeDynamicClient.ClearActions()
+
+	// --- Second Apply Run (with Prune) ---
+	ioStreams2, _, buf2, errBuf2 := genericiooptions.NewTestIOStreams()
+	secondRunApplyFlags := NewApplyFlags(ioStreams2)
+	secondRunCmd := &cobra.Command{}
+	secondRunApplyFlags.AddFlags(secondRunCmd)
+
+	secondRunCmd.Flags().Set("filename", filepath.Join(testDataPath, podFile11))
+	secondRunCmd.Flags().Set("prune", "true")
+	secondRunCmd.Flags().Set("selector", "test=managed")
+
+	var o2 *ApplyOptions
+	o2, err = secondRunApplyFlags.ToOptions(tf, secondRunCmd, "kubectl", []string{})
+	if err != nil {
+		t.Fatalf("Error creating ApplyOptions for second run: %v", err)
+	}
+	o2.Namespace = ""
+	o2.EnforceNamespace = false
+	o2.ServerSideApply = false
+	if errRun := o2.Run(); errRun != nil {
+		if tf.FakeDynamicClient != nil {
+			t.Logf("FakeDynamicClient actions at time of error (second run): %#v", tf.FakeDynamicClient.Actions())
+		}
+		t.Fatalf("unexpected error during second apply (prune) run: %v\nOutput: %s\nErrorOutput: %s", errRun, buf2.String(), errBuf2.String())
+	}
+
+	visitedUIDsListO2 := make([]string, 0, o2.VisitedUids.Len())
+	for uid_o2 := range o2.VisitedUids { // Renamed uid to uid_o2 to avoid conflict with err variable if any
+		visitedUIDsListO2 = append(visitedUIDsListO2, string(uid_o2))
+	}
+	t.Logf("VisitedUids after second o2.Run() (prune run): %v", visitedUIDsListO2)
+
+
+	deletedPods := []string{}
+	secondRunActions := tf.FakeDynamicClient.Actions()
+	deleteCount := 0
+	for _, action := range secondRunActions {
+		if action.GetVerb() == "delete" && action.GetResource() == gvrPod {
+			deleteAction := action.(clientgotesting.DeleteActionImpl)
+			deletedPods = append(deletedPods, deleteAction.GetName())
+			deleteCount++
+		}
+	}
+
+	updateCountDuringSecondRun := 0
+	for _, action := range secondRunActions {
+		if action.GetVerb() == "update" && action.GetResource() == gvrPod {
+			updateCountDuringSecondRun++
+		}
+	}
+	assert.Equal(t, 1, updateCountDuringSecondRun, "Expected 1 update action for the pod in the prune run input file")
+
+	assert.Equal(t, 2, deleteCount, "Expected 2 delete actions for the pruned pods")
+	assert.Contains(t, deletedPods, podSecond1FromFile.GetName(), "podSecond1 should be pruned")
+	assert.Contains(t, deletedPods, podSecond2FromFile.GetName(), "podSecond2 should be pruned")
+	assert.NotContains(t, deletedPods, podFirstFromFile.GetName(), "podFirst should not be pruned")
+
+	_, errCheck1 := tf.FakeDynamicClient.Resource(gvrPod).Namespace(podFirstLive.GetNamespace()).Get(context.TODO(), podFirstLive.GetName(), metav1.GetOptions{})
+	assert.NoError(t, errCheck1, "podFirst should still exist after pruning run")
+
+	_, errCheck2 := tf.FakeDynamicClient.Resource(gvrPod).Namespace(podSecond1Live.GetNamespace()).Get(context.TODO(), podSecond1Live.GetName(), metav1.GetOptions{})
+	assert.True(t, apierrors.IsNotFound(errCheck2), "podSecond1 should be deleted after pruning run")
+	_, errCheck3 := tf.FakeDynamicClient.Resource(gvrPod).Namespace(podSecond2Live.GetNamespace()).Get(context.TODO(), podSecond2Live.GetName(), metav1.GetOptions{})
+	assert.True(t, apierrors.IsNotFound(errCheck3), "podSecond2 should be deleted after pruning run")
 }

--- a/pkg/cmd/apply/prune_test.go
+++ b/pkg/cmd/apply/prune_test.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"io"
 	"net/http"
+	"path"
 	"strings"
 	"testing"
 
@@ -40,6 +41,11 @@ const (
 	podFile22    = "prune-pod-second-2.yaml"
 )
 
+const (
+	firstPodsCollection  = "/namespaces/first/pods"
+	secondPodsCollection = "/namespaces/second/pods"
+)
+
 var (
 	codecPrune = scheme.Codecs.LegacyCodec(scheme.Scheme.PrioritizedVersionsAllGroups()...)
 )
@@ -50,26 +56,38 @@ func TestPruneTwoNamespaces(t *testing.T) {
 
 	// Read the pod from the first file that will be kept
 	podFirst := readUnstructuredFromFile(t, testDataPath+podFile11)
-	urlFirstPod := "/namespaces/first/pods/p11"
-	firstPodsCollection := "/namespaces/first/pods"
+
 	podSecond1 := readUnstructuredFromFile(t, testDataPath+podFile21)
 	podSecond2 := readUnstructuredFromFile(t, testDataPath+podFile22)
-	urlSecondPod1 := "/namespaces/second/pods/p21"
-	urlSecondPod2 := "/namespaces/second/pods/p22"
-	secondPodsCollection := "/namespaces/second/pods"
 
 	tf := cmdtesting.NewTestFactory()
 	defer tf.Cleanup()
 
-	firstPodDeleted := false
-	secondPod1Deleted := false
-	secondPod2Deleted := false
+	// these are created for simple book keeping an ease of lookup.
+	// the book keeping is made in the most simple way possible to avoid creating a lot of test code.
+	// the pods are specifically named so that you don't have to even keep track of a namespace.
+	podMap := map[string]*unstructured.Unstructured{
+		"p11": podFirst,
+		"p21": podSecond1,
+		"p22": podSecond2,
+	}
+
+	podExistMap := map[string]bool{
+		"p11": false,
+		"p21": false,
+		"p22": false,
+	}
 
 	// Set up the fake REST client to handle HTTP requests
+	// NOTE that a lot of the error cases are not handled here to avoid generating too much test code.
+	// we would rather see a "panic" than add handlers where we don't expect
 	tf.UnstructuredClient = &fake.RESTClient{
 		NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
 		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 			switch p, m := req.URL.Path, req.Method; {
+
+			// Handle all the namespace GET's they all "exist"
+
 			case strings.HasPrefix(p, "/api/v1/namespaces/") && m == "GET":
 				namespace := strings.TrimPrefix(p, "/api/v1/namespaces/")
 				// Return namespace exists
@@ -85,78 +103,57 @@ func TestPruneTwoNamespaces(t *testing.T) {
 					Header:     cmdtesting.DefaultHeader(),
 					Body:       io.NopCloser(strings.NewReader(nsResponse))}, nil
 
+			// all the LISTS
+			case strings.HasPrefix(p, firstPodsCollection) && m == "GET" && strings.Contains(p, "?"):
+				// Return list with p11 pod for first namespace
+				pb, _ := runtime.Encode(codecPrune, podMap["p11"])
+				listResponse := `{"kind":"List","apiVersion":"v1","items":[` + string(pb) + `]}`
+				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: io.NopCloser(strings.NewReader(listResponse))}, nil
+			case strings.HasPrefix(p, secondPodsCollection) && m == "GET" && strings.Contains(p, "?"):
+				// Handle the list response for pruning
+				p1b, _ := runtime.Encode(codecPrune, podMap["p21"])
+				p2b, _ := runtime.Encode(codecPrune, podMap["p22"])
+				listResponse := `{"kind":"List","apiVersion":"v1","items":[` + string(p1b) + `,` + string(p2b) + `]}`
+				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: io.NopCloser(strings.NewReader(listResponse))}, nil
+
 			// All the GETs return 404
 			// the reason is that if we return the objects here kubectl decides that they already
 			// exist and tries to do a patch.
-			case (p == urlFirstPod || p == urlSecondPod1 || p == urlSecondPod2) && m == "GET":
-				// Simulate not found for GET and PATCH
-				return &http.Response{
-					StatusCode: http.StatusNotFound,
-					Header:     cmdtesting.DefaultHeader(),
-					Body:       io.NopCloser(strings.NewReader(``)),
-				}, nil
+			case urlInCollections(p) && (m == "GET" || m == "PATCH"):
+				name := path.Base(p)
 
-			// All the POSTs
-			case p == firstPodsCollection && m == "POST":
-				// Create the pod in first namespace
+				if !podExistMap[name] {
+					// If the pod does not exist, return 404
+					return &http.Response{
+						StatusCode: http.StatusNotFound,
+						Header:     cmdtesting.DefaultHeader(),
+					}, nil
+				}
+
+				pod := podMap[name]
+				podBytes, _ := runtime.Encode(codecPrune, pod)
+				bodyPod := io.NopCloser(bytes.NewReader(podBytes))
+				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: bodyPod}, nil
+
+			// All the Pod POSTs
+			case urlInCollections(p) && m == "POST":
+
+				name := readPodName(t, req.Body)
+				podExistMap[name] = true
+				pod := podMap[name]
 				setLastAppliedConfigAnnotation(podFirst)
-				podBytes, _ := runtime.Encode(codecPrune, podFirst)
-				bodyPod := io.NopCloser(bytes.NewReader(podBytes))
-				return &http.Response{StatusCode: http.StatusCreated, Header: cmdtesting.DefaultHeader(), Body: bodyPod}, nil
-			case p == secondPodsCollection && m == "POST":
-				// Create the pod in second namespace
-				bodyBytes, err := io.ReadAll(req.Body)
-				if err != nil {
-					t.Fatalf("unexpected error: %v", err)
-				}
-				obj := &unstructured.Unstructured{}
-				if err := runtime.DecodeInto(codecPrune, bodyBytes, obj); err != nil {
-					t.Fatalf("unexpected error: %v", err)
-				}
-
-				var podToReturn *unstructured.Unstructured
-				switch obj.GetName() {
-				case "p21":
-					setLastAppliedConfigAnnotation(podSecond1)
-					podToReturn = podSecond1
-				case "p22":
-					setLastAppliedConfigAnnotation(podSecond2)
-					podToReturn = podSecond2
-				default:
-					t.Fatalf("unexpected pod name: %s", obj.GetName())
-				}
-
-				podBytes, _ := runtime.Encode(codecPrune, podToReturn)
+				podBytes, _ := runtime.Encode(codecPrune, pod)
 				bodyPod := io.NopCloser(bytes.NewReader(podBytes))
 				return &http.Response{StatusCode: http.StatusCreated, Header: cmdtesting.DefaultHeader(), Body: bodyPod}, nil
 
-			// All the DELETE
-			case p == urlFirstPod && m == "DELETE":
-				// Delete the first pod in second namespace
-				firstPodDeleted = true
-				podBytes, _ := runtime.Encode(codecPrune, podFirst)
+			// All the DELETEs
+			case urlInCollections(p) && m == "DELETE":
+				name := path.Base(p)
+				podExistMap[name] = false
+				pod := podMap[name]
+				podBytes, _ := runtime.Encode(codecPrune, pod)
 				bodyPod := io.NopCloser(bytes.NewReader(podBytes))
 				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: bodyPod}, nil
-			case p == urlSecondPod1 && m == "DELETE":
-				// Delete the first pod in second namespace
-				secondPod1Deleted = true
-				podBytes, _ := runtime.Encode(codecPrune, podSecond1)
-				bodyPod := io.NopCloser(bytes.NewReader(podBytes))
-				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: bodyPod}, nil
-			case p == urlSecondPod2 && m == "DELETE":
-				// Delete the second pod in second namespace
-				secondPod2Deleted = true
-				podBytes, _ := runtime.Encode(codecPrune, podSecond2)
-				bodyPod := io.NopCloser(bytes.NewReader(podBytes))
-				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: bodyPod}, nil
-
-			// all the LISTS
-			case strings.HasPrefix(p, firstPodsCollection) && m == "GET" && strings.Contains(p, "?"):
-				// Handle list requests for pruning - return empty lists
-				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: io.NopCloser(strings.NewReader(`{"kind":"List","apiVersion":"v1","items":[]}`))}, nil
-			case strings.HasPrefix(p, secondPodsCollection) && m == "GET" && strings.Contains(p, "?"):
-				// Handle list requests for pruning - return empty lists
-				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: io.NopCloser(strings.NewReader(`{"kind":"List","apiVersion":"v1","items":[]}`))}, nil
 
 			default:
 				t.Fatalf("unexpected request: %s %s", m, p)
@@ -174,17 +171,49 @@ func TestPruneTwoNamespaces(t *testing.T) {
 	cmd.Flags().Set("output", "name")
 	cmd.Run(cmd, []string{})
 
-	// we have asked for the names to be output so we should get all of them in the output string
-	outString := buf.String()
-	assert.Contains(t, outString, "pod/p11")
-	assert.Contains(t, outString, "pod/p21")
-	assert.Contains(t, outString, "pod/p22")
 	if errBuf.String() != "" {
 		t.Fatalf("unexpected error output: %s", errBuf.String())
 	}
 
+	// we have asked for the names to be output so we should get all of them in the output string
+	outString := buf.String()
 	// at this point in time none of our pods should be deleted.
-	assert.False(t, firstPodDeleted, "first pod should not be deleted")
-	assert.False(t, secondPod1Deleted, "second pod 1 should not be deleted")
-	assert.False(t, secondPod2Deleted, "second pod 2 should not be deleted")
+	// and they all should be represented in the output
+	for name, exists := range podExistMap {
+		assert.True(t, exists, "pod %s should not be deleted", name)
+		assert.Contains(t, outString, "pod/"+name)
+	}
+
+	// the second run should prune the p2* pods
+	ioStreams, _, _, errBuf = genericiooptions.NewTestIOStreams()
+	cmd = NewCmdApply("kubectl", tf, ioStreams)
+	cmd.Flags().Set("filename", testDataPath+podFile11)
+	cmd.Flags().Set("prune", "true")
+	cmd.Flags().Set("selector", "test=managed")
+	cmd.Run(cmd, []string{})
+	if errBuf.String() != "" {
+		t.Fatalf("unexpected error output: %s", errBuf.String())
+	}
+
+	assert.False(t, podExistMap["p21"], "pod p21 should be deleted")
+	assert.False(t, podExistMap["p22"], "pod p22 should be deleted")
+}
+
+// urlInCollections checks if the given URL is part of the collections we are interested in.
+func urlInCollections(url string) bool {
+	return strings.HasPrefix(url, firstPodsCollection) ||
+		strings.HasPrefix(url, secondPodsCollection)
+}
+
+// readUnstructuredFromFile reads a request body and returns a names
+func readPodName(t *testing.T, body io.ReadCloser) string {
+	bodyBytes, err := io.ReadAll(body)
+	if err != nil {
+		t.Fatalf("failed to read request body: %v", err)
+	}
+	obj := &unstructured.Unstructured{}
+	if err := runtime.DecodeInto(codecPrune, bodyBytes, obj); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	return obj.GetName()
 }

--- a/pkg/cmd/apply/prune_test.go
+++ b/pkg/cmd/apply/prune_test.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/resource"
@@ -33,11 +34,9 @@ import (
 
 const (
 	testDataPath = "testdata/prune/prune-two-ns/"
-	podFirstNs   = "prune-pod-first.yaml"
-	podSecondNs1 = "prune-pod-second-1.yaml"
-	podSecondNs2 = "prune-pod-second-2.yaml"
-	nameFirst    = "default-http-1"
-	nameSecond   = "default-http-1"
+	podFile11    = "prune-pod-first.yaml"
+	podFile21    = "prune-pod-second-1.yaml"
+	podFile22    = "prune-pod-second-2.yaml"
 )
 
 var (
@@ -45,15 +44,25 @@ var (
 )
 
 func TestPruneTwoNamespaces(t *testing.T) {
+
 	cmdtesting.InitTestErrorHandler(t)
 
 	// Read the pod from the first file that will be kept
-	podFirst := readUnstructuredFromFile(t, testDataPath+podFirstNs)
-	pathFirstPod := "/namespaces/first/pods/" + nameFirst
-	pathFirstPodsCollection := "/namespaces/first/pods"
+	podFirst := readUnstructuredFromFile(t, testDataPath+podFile11)
+	urlFirstPod := "/namespaces/first/pods/p11"
+	firstPodsCollection := "/namespaces/first/pods"
+	podSecond1 := readUnstructuredFromFile(t, testDataPath+podFile21)
+	podSecond2 := readUnstructuredFromFile(t, testDataPath+podFile22)
+	urlSecondPod1 := "/namespaces/second/pods/p21"
+	urlSecondPod2 := "/namespaces/second/pods/p22"
+	secondPodsCollection := "/namespaces/second/pods"
 
 	tf := cmdtesting.NewTestFactory()
 	defer tf.Cleanup()
+
+	firstPodDeleted := false
+	secondPod1Deleted := false
+	secondPod2Deleted := false
 
 	// Set up the fake REST client to handle HTTP requests
 	tf.UnstructuredClient = &fake.RESTClient{
@@ -80,17 +89,61 @@ func TestPruneTwoNamespaces(t *testing.T) {
 					}
 				}`
 				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: io.NopCloser(strings.NewReader(nsResponse))}, nil
-			case p == pathFirstPod && m == "GET":
-				// Return 404 to simulate the pod doesn't exist yet
-				return &http.Response{StatusCode: http.StatusNotFound, Header: cmdtesting.DefaultHeader(), Body: io.NopCloser(strings.NewReader(""))}, nil
-			case p == pathFirstPodsCollection && m == "POST":
+
+			// All the GETs
+			case p == urlFirstPod && (m == "GET" || m == "PATCH"):
+				podBytes, _ := runtime.Encode(codecPrune, podFirst)
+				bodyPod := io.NopCloser(bytes.NewReader(podBytes))
+				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: bodyPod}, nil
+			case p == urlSecondPod1 && (m == "GET" || m == "PATCH"):
+				podBytes, _ := runtime.Encode(codecPrune, podSecond1)
+				bodyPod := io.NopCloser(bytes.NewReader(podBytes))
+				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: bodyPod}, nil
+			case p == urlSecondPod2 && (m == "GET" || m == "PATCH"):
+				podBytes, _ := runtime.Encode(codecPrune, podSecond2)
+				bodyPod := io.NopCloser(bytes.NewReader(podBytes))
+				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: bodyPod}, nil
+
+			// All the POSTs
+			case p == firstPodsCollection && m == "POST":
 				// Create the pod in first namespace
 				podBytes, _ := runtime.Encode(codecPrune, podFirst)
 				bodyPod := io.NopCloser(bytes.NewReader(podBytes))
 				return &http.Response{StatusCode: http.StatusCreated, Header: cmdtesting.DefaultHeader(), Body: bodyPod}, nil
-			case strings.HasPrefix(p, "/namespaces/first/pods") && m == "GET" && strings.Contains(p, "?"):
+			case p == secondPodsCollection && m == "POST":
+				// Create the pod in second namespace
+				podBytes, _ := runtime.Encode(codecPrune, podSecond1)
+				bodyPod := io.NopCloser(bytes.NewReader(podBytes))
+				return &http.Response{StatusCode: http.StatusCreated, Header: cmdtesting.DefaultHeader(), Body: bodyPod}, nil
+
+			// All the DELETE
+			case p == urlFirstPod && m == "DELETE":
+				// Delete the first pod in second namespace
+				firstPodDeleted = true
+				podBytes, _ := runtime.Encode(codecPrune, podFirst)
+				bodyPod := io.NopCloser(bytes.NewReader(podBytes))
+				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: bodyPod}, nil
+			case p == urlSecondPod1 && m == "DELETE":
+				// Delete the first pod in second namespace
+				secondPod1Deleted = true
+				podBytes, _ := runtime.Encode(codecPrune, podSecond1)
+				bodyPod := io.NopCloser(bytes.NewReader(podBytes))
+				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: bodyPod}, nil
+			case p == urlSecondPod2 && m == "DELETE":
+				// Delete the second pod in second namespace
+				secondPod2Deleted = true
+				podBytes, _ := runtime.Encode(codecPrune, podSecond2)
+				bodyPod := io.NopCloser(bytes.NewReader(podBytes))
+				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: bodyPod}, nil
+
+			// all the LISTS
+			case strings.HasPrefix(p, firstPodsCollection) && m == "GET" && strings.Contains(p, "?"):
 				// Handle list requests for pruning - return empty lists
 				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: io.NopCloser(strings.NewReader(`{"kind":"List","apiVersion":"v1","items":[]}`))}, nil
+			case strings.HasPrefix(p, secondPodsCollection) && m == "GET" && strings.Contains(p, "?"):
+				// Handle list requests for pruning - return empty lists
+				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: io.NopCloser(strings.NewReader(`{"kind":"List","apiVersion":"v1","items":[]}`))}, nil
+
 			default:
 				t.Fatalf("unexpected request: %s %s", m, p)
 				return nil, nil
@@ -101,16 +154,23 @@ func TestPruneTwoNamespaces(t *testing.T) {
 
 	ioStreams, _, buf, errBuf := genericiooptions.NewTestIOStreams()
 	cmd := NewCmdApply("kubectl", tf, ioStreams)
-	cmd.Flags().Set("filename", testDataPath+podFirstNs)
+	cmd.Flags().Set("filename", testDataPath+podFile11)
+	cmd.Flags().Set("filename", testDataPath+podFile21)
+	cmd.Flags().Set("filename", testDataPath+podFile22)
 	cmd.Flags().Set("output", "name")
 	cmd.Run(cmd, []string{})
 
-	// Check that the pod was applied successfully
-	expectedOutput := "pod/" + nameFirst + "\n"
-	if buf.String() != expectedOutput {
-		t.Fatalf("unexpected output: %s\nexpected: %s", buf.String(), expectedOutput)
-	}
+	// we have asked for the names to be output so we should get all of them in the output string
+	outString := buf.String()
+	assert.Contains(t, outString, "pod/p11")
+	assert.Contains(t, outString, "pod/p21")
+	assert.Contains(t, outString, "pod/p22")
 	if errBuf.String() != "" {
 		t.Fatalf("unexpected error output: %s", errBuf.String())
 	}
+
+	// at this point in time none of our pods should be deleted.
+	assert.False(t, firstPodDeleted, "first pod should not be deleted")
+	assert.False(t, secondPod1Deleted, "second pod 1 should not be deleted")
+	assert.False(t, secondPod2Deleted, "second pod 2 should not be deleted")
 }

--- a/pkg/cmd/apply/prune_test.go
+++ b/pkg/cmd/apply/prune_test.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apply
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+	"k8s.io/cli-runtime/pkg/resource"
+	"k8s.io/client-go/rest/fake"
+	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
+	"k8s.io/kubectl/pkg/scheme"
+)
+
+const (
+	testDataPath = "testdata/prune/prune-two-ns/"
+	podFirstNs   = "prune-pod-first.yaml"
+	podSecondNs1 = "prune-pod-second-1.yaml"
+	podSecondNs2 = "prune-pod-second-2.yaml"
+	nameFirst    = "default-http-1"
+	nameSecond   = "default-http-1"
+)
+
+var (
+	codecPrune = scheme.Codecs.LegacyCodec(scheme.Scheme.PrioritizedVersionsAllGroups()...)
+)
+
+func TestPruneTwoNamespaces(t *testing.T) {
+	cmdtesting.InitTestErrorHandler(t)
+
+	// Read the pod from the first file that will be kept
+	podFirst := readUnstructuredFromFile(t, testDataPath+podFirstNs)
+	pathFirstPod := "/namespaces/first/pods/" + nameFirst
+	pathFirstPodsCollection := "/namespaces/first/pods"
+
+	tf := cmdtesting.NewTestFactory()
+	defer tf.Cleanup()
+
+	// Set up the fake REST client to handle HTTP requests
+	tf.UnstructuredClient = &fake.RESTClient{
+		NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
+		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+			switch p, m := req.URL.Path, req.Method; {
+			case p == "/api/v1/namespaces/first" && m == "GET":
+				// Return namespace exists
+				nsResponse := `{
+					"kind": "Namespace",
+					"apiVersion": "v1",
+					"metadata": {
+						"name": "first"
+					}
+				}`
+				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: io.NopCloser(strings.NewReader(nsResponse))}, nil
+			case p == "/api/v1/namespaces/second" && m == "GET":
+				// Return namespace exists
+				nsResponse := `{
+					"kind": "Namespace",
+					"apiVersion": "v1",
+					"metadata": {
+						"name": "second"
+					}
+				}`
+				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: io.NopCloser(strings.NewReader(nsResponse))}, nil
+			case p == pathFirstPod && m == "GET":
+				// Return 404 to simulate the pod doesn't exist yet
+				return &http.Response{StatusCode: http.StatusNotFound, Header: cmdtesting.DefaultHeader(), Body: io.NopCloser(strings.NewReader(""))}, nil
+			case p == pathFirstPodsCollection && m == "POST":
+				// Create the pod in first namespace
+				podBytes, _ := runtime.Encode(codecPrune, podFirst)
+				bodyPod := io.NopCloser(bytes.NewReader(podBytes))
+				return &http.Response{StatusCode: http.StatusCreated, Header: cmdtesting.DefaultHeader(), Body: bodyPod}, nil
+			case strings.HasPrefix(p, "/namespaces/first/pods") && m == "GET" && strings.Contains(p, "?"):
+				// Handle list requests for pruning - return empty lists
+				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: io.NopCloser(strings.NewReader(`{"kind":"List","apiVersion":"v1","items":[]}`))}, nil
+			default:
+				t.Fatalf("unexpected request: %s %s", m, p)
+				return nil, nil
+			}
+		}),
+	}
+	tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
+
+	ioStreams, _, buf, errBuf := genericiooptions.NewTestIOStreams()
+	cmd := NewCmdApply("kubectl", tf, ioStreams)
+	cmd.Flags().Set("filename", testDataPath+podFirstNs)
+	cmd.Flags().Set("output", "name")
+	cmd.Run(cmd, []string{})
+
+	// Check that the pod was applied successfully
+	expectedOutput := "pod/" + nameFirst + "\n"
+	if buf.String() != expectedOutput {
+		t.Fatalf("unexpected output: %s\nexpected: %s", buf.String(), expectedOutput)
+	}
+	if errBuf.String() != "" {
+		t.Fatalf("unexpected error output: %s", errBuf.String())
+	}
+}

--- a/pkg/cmd/apply/prune_test.go
+++ b/pkg/cmd/apply/prune_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/resource"
@@ -69,50 +70,63 @@ func TestPruneTwoNamespaces(t *testing.T) {
 		NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
 		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 			switch p, m := req.URL.Path, req.Method; {
-			case p == "/api/v1/namespaces/first" && m == "GET":
+			case strings.HasPrefix(p, "/api/v1/namespaces/") && m == "GET":
+				namespace := strings.TrimPrefix(p, "/api/v1/namespaces/")
 				// Return namespace exists
 				nsResponse := `{
 					"kind": "Namespace",
 					"apiVersion": "v1",
 					"metadata": {
-						"name": "first"
+						"name": "` + namespace + `"
 					}
 				}`
-				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: io.NopCloser(strings.NewReader(nsResponse))}, nil
-			case p == "/api/v1/namespaces/second" && m == "GET":
-				// Return namespace exists
-				nsResponse := `{
-					"kind": "Namespace",
-					"apiVersion": "v1",
-					"metadata": {
-						"name": "second"
-					}
-				}`
-				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: io.NopCloser(strings.NewReader(nsResponse))}, nil
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header:     cmdtesting.DefaultHeader(),
+					Body:       io.NopCloser(strings.NewReader(nsResponse))}, nil
 
-			// All the GETs
-			case p == urlFirstPod && (m == "GET" || m == "PATCH"):
-				podBytes, _ := runtime.Encode(codecPrune, podFirst)
-				bodyPod := io.NopCloser(bytes.NewReader(podBytes))
-				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: bodyPod}, nil
-			case p == urlSecondPod1 && (m == "GET" || m == "PATCH"):
-				podBytes, _ := runtime.Encode(codecPrune, podSecond1)
-				bodyPod := io.NopCloser(bytes.NewReader(podBytes))
-				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: bodyPod}, nil
-			case p == urlSecondPod2 && (m == "GET" || m == "PATCH"):
-				podBytes, _ := runtime.Encode(codecPrune, podSecond2)
-				bodyPod := io.NopCloser(bytes.NewReader(podBytes))
-				return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: bodyPod}, nil
+			// All the GETs return 404
+			// the reason is that if we return the objects here kubectl decides that they already
+			// exist and tries to do a patch.
+			case (p == urlFirstPod || p == urlSecondPod1 || p == urlSecondPod2) && m == "GET":
+				// Simulate not found for GET and PATCH
+				return &http.Response{
+					StatusCode: http.StatusNotFound,
+					Header:     cmdtesting.DefaultHeader(),
+					Body:       io.NopCloser(strings.NewReader(``)),
+				}, nil
 
 			// All the POSTs
 			case p == firstPodsCollection && m == "POST":
 				// Create the pod in first namespace
+				setLastAppliedConfigAnnotation(podFirst)
 				podBytes, _ := runtime.Encode(codecPrune, podFirst)
 				bodyPod := io.NopCloser(bytes.NewReader(podBytes))
 				return &http.Response{StatusCode: http.StatusCreated, Header: cmdtesting.DefaultHeader(), Body: bodyPod}, nil
 			case p == secondPodsCollection && m == "POST":
 				// Create the pod in second namespace
-				podBytes, _ := runtime.Encode(codecPrune, podSecond1)
+				bodyBytes, err := io.ReadAll(req.Body)
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				obj := &unstructured.Unstructured{}
+				if err := runtime.DecodeInto(codecPrune, bodyBytes, obj); err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+
+				var podToReturn *unstructured.Unstructured
+				switch obj.GetName() {
+				case "p21":
+					setLastAppliedConfigAnnotation(podSecond1)
+					podToReturn = podSecond1
+				case "p22":
+					setLastAppliedConfigAnnotation(podSecond2)
+					podToReturn = podSecond2
+				default:
+					t.Fatalf("unexpected pod name: %s", obj.GetName())
+				}
+
+				podBytes, _ := runtime.Encode(codecPrune, podToReturn)
 				bodyPod := io.NopCloser(bytes.NewReader(podBytes))
 				return &http.Response{StatusCode: http.StatusCreated, Header: cmdtesting.DefaultHeader(), Body: bodyPod}, nil
 

--- a/pkg/cmd/apply/testdata/prune/prune-two-ns/prune-pod-first.yaml
+++ b/pkg/cmd/apply/testdata/prune/prune-two-ns/prune-pod-first.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: default-http-backend
+    test: managed
+  name: default-http-1
+  namespace: first
+spec:
+  containers:
+  - image: gcr.io/google_containers/defaultbackend:1.4
+    imagePullPolicy: IfNotPresent
+    name: default-http-backend
+    ports:
+    - containerPort: 8080
+      protocol: TCP

--- a/pkg/cmd/apply/testdata/prune/prune-two-ns/prune-pod-first.yaml
+++ b/pkg/cmd/apply/testdata/prune/prune-two-ns/prune-pod-first.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: default-http-backend
     test: managed
-  name: default-http-1
+  name: p11
   namespace: first
 spec:
   containers:

--- a/pkg/cmd/apply/testdata/prune/prune-two-ns/prune-pod-second-1.yaml
+++ b/pkg/cmd/apply/testdata/prune/prune-two-ns/prune-pod-second-1.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: default-http-backend
+    test: managed
+  name: default-http-1
+  namespace: second
+spec:
+  containers:
+  - image: gcr.io/google_containers/defaultbackend:1.4
+    imagePullPolicy: IfNotPresent
+    name: default-http-backend
+    ports:
+    - containerPort: 8080
+      protocol: TCP

--- a/pkg/cmd/apply/testdata/prune/prune-two-ns/prune-pod-second-1.yaml
+++ b/pkg/cmd/apply/testdata/prune/prune-two-ns/prune-pod-second-1.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: default-http-backend
     test: managed
-  name: default-http-1
+  name: p21
   namespace: second
 spec:
   containers:

--- a/pkg/cmd/apply/testdata/prune/prune-two-ns/prune-pod-second-2.yaml
+++ b/pkg/cmd/apply/testdata/prune/prune-two-ns/prune-pod-second-2.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: default-http-backend
+    test: managed
+  name: default-http-2
+  namespace: second
+spec:
+  containers:
+  - image: gcr.io/google_containers/defaultbackend:1.4
+    imagePullPolicy: IfNotPresent
+    name: default-http-backend
+    ports:
+    - containerPort: 8080
+      protocol: TCP

--- a/pkg/cmd/apply/testdata/prune/prune-two-ns/prune-pod-second-2.yaml
+++ b/pkg/cmd/apply/testdata/prune/prune-two-ns/prune-pod-second-2.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: default-http-backend
     test: managed
-  name: default-http-2
+  name: p22
   namespace: second
 spec:
   containers:


### PR DESCRIPTION
This pull request enhances the pruning functionality in the `kubectl apply` command by introducing more granular namespace selection and adding comprehensive tests. The key changes include refactoring the pruning logic to support label-based namespace filtering, adding helper methods for namespace and resource checks, and creating detailed unit tests with test data.

